### PR TITLE
Edition 2018 Upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/mbillingr/ambisonic"
 description = "Compose and play 3D audio."
 readme = "README.md"
+edition = "2018"
 
 categories = ["multimedia", "multimedia::audio", "game-engines"]
 keywords = ["audio", "ambisonics", "3D", "sound", "gamedev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["audio", "ambisonics", "3D", "sound", "gamedev"]
 [dependencies]
 cpal = "0.8"
 rodio = "0.8"
-rand = "0.5"
+rand = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 ## Compose and play 3D audio.
 
-The library provides 3D sound scene support on top of [`rodio`](https://crates.io/crates/rodio).
+The ambisonic library provides 3D sound scene support on top of [`rodio`](https://crates.io/crates/rodio).
 It allows positioning and moving sound sources freely in 3D space around a virtual listener,
 and playing the resulting spatial mix in real-time over a sound card.
+
+### Features:
+- Realistic directional audio
+- Take `rodio` sound sources and place them in space
+- Doppler effect on moving sounds
+
+### Technical Details
 
 `ambisonic` is built around the concept of an intermediate representation of the sound field,
 called *B-format*. The *B-format* describes what the listener should hear, independent of

--- a/src/bmixer.rs
+++ b/src/bmixer.rs
@@ -64,7 +64,8 @@ impl Iterator for BstreamMixer {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.controller.has_pending.load(Ordering::SeqCst) {
-            let mut pending = self.controller
+            let mut pending = self
+                .controller
                 .pending_streams
                 .lock()
                 .expect("Cannot lock pending streams");

--- a/src/bmixer.rs
+++ b/src/bmixer.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 use rodio::{source::UniformSourceIterator, Sample, Source};
 
-use bformat::Bformat;
-use bstream::{self, Bstream, SoundController};
+use crate::bformat::Bformat;
+use crate::bstream::{self, Bstream, SoundController};
 
 /// Construct a 3D sound mixer and associated sound composer.
 pub fn bmixer(sample_rate: u32) -> (BstreamMixer, Arc<BmixerComposer>) {

--- a/src/bstream.rs
+++ b/src/bstream.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use rodio::Source;
 
-use bformat::{Bformat, Bweights};
+use crate::bformat::{Bformat, Bweights};
 
 /// Convert a `rodio::Source` to a spatial `Bstream` source with associated controller
 ///
@@ -46,7 +46,7 @@ pub fn bstream<I: Source<Item = f32> + Send + 'static>(source: I) -> (Bstream, S
 ///
 /// Consumes samples from the inner source and converts them to *B-format* samples.
 pub struct Bstream {
-    input: Box<Source<Item = f32> + Send>,
+    input: Box<dyn Source<Item = f32> + Send>,
     bridge: Arc<BstreamBridge>,
 
     bweights: Bweights,

--- a/src/bstream.rs
+++ b/src/bstream.rs
@@ -36,7 +36,7 @@ pub fn bstream<I: Source<Item = f32> + Send + 'static>(source: I) -> (Bstream, S
         sampling_offset: 0.0,
         previous_sample: 0.0,
         next_sample: 0.0,
-        bridge: bridge,
+        bridge,
     };
 
     (stream, controller)
@@ -215,7 +215,8 @@ impl SoundController {
 
         let relative_velocity = (self.position[0] * self.velocity[0]
             + self.position[1] * self.velocity[1]
-            + self.position[2] * self.velocity[2]) / dist;
+            + self.position[2] * self.velocity[2])
+            / dist;
 
         self.speed_of_sound / (self.speed_of_sound + self.doppler_factor * relative_velocity)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,6 @@
 //! sound.set_velocity([0.0, 0.0, 0.0]);
 //! ```
 
-
-
 pub use rodio;
 
 mod bformat;
@@ -102,7 +100,8 @@ impl AmbisonicBuilder {
 
     /// Build the ambisonic context
     pub fn build(self) -> Ambisonic {
-        let device = self.device
+        let device = self
+            .device
             .unwrap_or_else(|| rodio::default_output_device().unwrap());
         let sink = rodio::Sink::new(&device);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@
 //! sound.set_velocity([0.0, 0.0, 0.0]);
 //! ```
 
-extern crate cpal;
-extern crate rand;
-pub extern crate rodio;
+
+
+pub use rodio;
 
 mod bformat;
 mod bmixer;
@@ -56,9 +56,9 @@ pub mod sources;
 use std::f32;
 use std::sync::Arc;
 
-use bmixer::BmixerComposer;
-pub use bstream::SoundController;
-pub use renderer::{HrtfConfig, StereoConfig};
+use crate::bmixer::BmixerComposer;
+pub use crate::bstream::SoundController;
+pub use crate::renderer::{HrtfConfig, StereoConfig};
 
 /// Configure playback parameters
 pub enum PlaybackConfiguration {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use rodio::Source;
 
-use bformat::{Bformat, Bweights};
+use crate::bformat::{Bformat, Bweights};
 
 /// Stereo Playback configuration
 ///

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -244,7 +244,8 @@ where
 
                 let (mut left, mut right) = (0.0, 0.0);
 
-                for (speaker, buffer) in self.virtual_speakers
+                for (speaker, buffer) in self
+                    .virtual_speakers
                     .iter()
                     .zip(self.convolution_buffers.iter_mut())
                 {
@@ -279,6 +280,8 @@ struct VirtualSpeaker {
     right_hrir: Vec<f32>,
 }
 
+#[allow(clippy::excessive_precision)]
+#[allow(clippy::unreadable_literal)]
 impl Default for HrtfConfig {
     fn default() -> Self {
         HrtfConfig {

--- a/src/sources/noise.rs
+++ b/src/sources/noise.rs
@@ -1,5 +1,6 @@
 use rand::{
-    distributions::{Distribution, StandardNormal}, thread_rng,
+    distributions::{Distribution, StandardNormal},
+    thread_rng,
 };
 use rodio::Source;
 use std::time::Duration;


### PR DESCRIPTION
I thought that this crate used `-> Box<dyn Trait>`  return patterns which could be replaced with ` -> impl Trait` . I was wrong... confused it with another project of mine.

Although the upgrade does not have an obvious benefit I'll stick with it as a signpost that the project is still maintained :)